### PR TITLE
Support PowerShell 5.1

### DIFF
--- a/lib/commands.ps1
+++ b/lib/commands.ps1
@@ -8,9 +8,7 @@ function get_commands {
 
 
 function command_files {
-    (Get-ChildItem (relpath '..\libexec')) `
-        # + (Get-ChildItem "$rbenvdir\shims") `
-        | Where-Object { $_.name -match 'rbenv-.*?\.ps1$' }
+    (Get-ChildItem (relpath '..\libexec')) | Where-Object { $_.name -match 'rbenv-.*?\.ps1$' }
 }
 
 

--- a/lib/version.ps1
+++ b/lib/version.ps1
@@ -79,9 +79,7 @@ function get_all_remote_versions {
 # Read all dir names in the RBENV_ROOT
 function get_all_installed_versions {
     # System.IO.DirectoryInfo
-    $versions = (Get-ChildItem ($env:RBENV_ROOT)) `
-                # + (Get-ChildItem "$rbenvdir\shims") `
-                | Where-Object {
+    $versions = (Get-ChildItem ($env:RBENV_ROOT)) | Where-Object {
                     $_.Name -match $(version_match_regexp) -or $_.Name -eq 'head'
                 }
 


### PR DESCRIPTION
Fix ```An empty pipe is not allowed``` error