### PR TITLE
Use ASCII encoding for global version file

### DIFF
--- a/libexec/rbenv-global.ps1
+++ b/libexec/rbenv-global.ps1
@@ -7,7 +7,7 @@ function set_global_version($version) {
 
     $version = auto_fix_version_for_installed $version
 
-    $version | Out-File $GLOBAL_VERSION_FILE -NoNewline
+    $version | Out-File $GLOBAL_VERSION_FILE -NoNewline -Encoding ascii
 
     success "rbenv: Change to global version '$version'"
 


### PR DESCRIPTION
In Powershell 5.1, `Out-File` command uses UTF-16 encoding as default.

This will lead to weird version text read from global version file because of Unicode BOM.

![global_version_file](https://user-images.githubusercontent.com/14920359/227569833-60fe60d9-569f-4153-a656-de281c0d2618.png)

This PR fixes this by specifying ASCII encoding for `Out-File`.

FIY: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/out-file?view=powershell-5.1#-encoding