### PR TITLE
docs: Include instruction to restart terminal after updating $profile configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ $env:RBENV_ROOT = "C:\Ruby-on-Windows"
 
 & "$env:RBENV_ROOT\rbenv\bin\rbenv.ps1" init
 ```
+After adding these configurations to your $profile, restart your terminal for the changes to take effect.
 
 To update, use the following command:
 


### PR DESCRIPTION
By adding documentation specifying the need to restart the terminal after modifying the $profile configurations, users can easily follow the necessary steps to ensure the changes take effect.